### PR TITLE
Feature/new build system

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,3 +4,4 @@ osx_image: xcode10.2
 script:
 - set -o pipefail
 - swift --version
+- make build

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+TOOL_NAME = poe
+
+PREFIX = /usr/local
+INSTALL_PATH = $(PREFIX)/bin/$(TOOL_NAME)
+BUILD_PATH = .build/release/$(TOOL_NAME)
+
+install: build
+	install -d "$(PREFIX)/bin"
+	install -C -m 755 $(BUILD_PATH) $(INSTALL_PATH)
+
+build:
+	swift build --disable-sandbox -c release 
+
+uninstall:
+	rm -f $(INSTALL_PATH)

--- a/POEditor-Parser.podspec
+++ b/POEditor-Parser.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "POEditor-Parser"
-  s.version      = "1.0.0"
+  s.version      = "1.0.1"
   s.summary      = "`POEditor-Parser` generates a swift file with an input strings file from POEditor"
 
   s.description  = <<-DESC

--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/kylef/Commander",
         "state": {
           "branch": null,
-          "revision": "e5b50ad7b2e91eeb828393e89b03577b16be7db9",
-          "version": "0.8.0"
+          "revision": "4b6133c3071d521489a80c38fb92d7983f19d438",
+          "version": "0.9.1"
         }
       },
       {
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/PerfectlySoft/Perfect-COpenSSL.git",
         "state": {
           "branch": null,
-          "revision": "b8bd953a390940b486ce8119a61c8d5ad9d5c31c",
-          "version": "3.1.5"
+          "revision": "ce3113e159b8c6d8565e5d8db2672b572c81aea9",
+          "version": "4.0.2"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/PerfectlySoft/Perfect-Crypto.git",
         "state": {
           "branch": null,
-          "revision": "54e0f7c2a9d7355fca3c23e0f88096ac3765e08b",
-          "version": "3.1.2"
+          "revision": "98373fa3a6c3d551e498c1babe4f25f650fa1310",
+          "version": "3.3.0"
         }
       },
       {
@@ -33,8 +33,8 @@
         "repositoryURL": "https://github.com/PerfectlySoft/Perfect-CURL",
         "state": {
           "branch": null,
-          "revision": "08ba26c7b768e9e2096d1fe475e0cef733b98a75",
-          "version": "3.0.7"
+          "revision": "a9f8950554585bd12b9ec24ad4bfbe0b1519e03f",
+          "version": "3.1.0"
         }
       },
       {
@@ -42,8 +42,8 @@
         "repositoryURL": "https://github.com/PerfectlySoft/Perfect-HTTP.git",
         "state": {
           "branch": null,
-          "revision": "5ad1f4bb8f60447f308b8d8d35289c5a1d74c54f",
-          "version": "3.1.3"
+          "revision": "122affd0bb5090c61bdc1e50e7f32ab6457d228e",
+          "version": "3.3.0"
         }
       },
       {
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/PerfectlySoft/Perfect-libcurl.git",
         "state": {
           "branch": null,
-          "revision": "672f6695d9ae04fce16ad01decef0649e0b872b0",
-          "version": "2.0.6"
+          "revision": "b3d7e65ef5c27c0a027cdc621f34835975301bf1",
+          "version": "2.1.0"
         }
       },
       {
@@ -60,8 +60,8 @@
         "repositoryURL": "https://github.com/PerfectlySoft/Perfect-Net.git",
         "state": {
           "branch": null,
-          "revision": "a04974a9abf20adea2082e802e20ee9cce829eeb",
-          "version": "3.2.1"
+          "revision": "d00b2b9f4cccb4c398e1bcf18f767d6b8add6af7",
+          "version": "3.3.0"
         }
       },
       {
@@ -69,8 +69,8 @@
         "repositoryURL": "https://github.com/PerfectlySoft/Perfect-Thread.git",
         "state": {
           "branch": null,
-          "revision": "04fcd2d29f50e05dbca907219322fd475c205c33",
-          "version": "3.0.5"
+          "revision": "a50b9a33f08fce638f33ae3121613fe499cc23ec",
+          "version": "3.0.7"
         }
       },
       {
@@ -78,8 +78,8 @@
         "repositoryURL": "https://github.com/PerfectlySoft/PerfectLib.git",
         "state": {
           "branch": null,
-          "revision": "60e44e4c62e293844581205528eefdc7e1153199",
-          "version": "3.1.2"
+          "revision": "5a08c2a596df23a3ae30b6ac9cb509a38384166c",
+          "version": "3.1.4"
         }
       },
       {
@@ -87,8 +87,8 @@
         "repositoryURL": "https://github.com/onevcat/Rainbow",
         "state": {
           "branch": null,
-          "revision": "797a68d0a642609424b08f11eb56974a54d5f6e2",
-          "version": "3.1.4"
+          "revision": "9c52c1952e9b2305d4507cf473392ac2d7c9b155",
+          "version": "3.1.5"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -11,9 +11,9 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-	.package(url: "https://github.com/kylef/Commander", from: "0.8.0"),
-	.package(url: "https://github.com/onevcat/Rainbow", from: "3.0.0"),
-    .package(url: "https://github.com/PerfectlySoft/Perfect-CURL", from: "3.0.0")
+	.package(url: "https://github.com/kylef/Commander", .upToNextMajor(from: "0.8.0")),
+	.package(url: "https://github.com/onevcat/Rainbow", .upToNextMajor(from: "3.0.0")),
+    .package(url: "https://github.com/PerfectlySoft/Perfect-CURL", .upToNextMajor(from: "3.0.0"))
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
@@ -21,5 +21,6 @@ let package = Package(
         .target(
             name: "POEditorParser",
             dependencies: ["Commander", "Rainbow", "PerfectCURL"])
-    ]
+    ],
+    swiftLanguageVersions: [.version("4"), .version("4.2")]
 )

--- a/README.md
+++ b/README.md
@@ -10,15 +10,28 @@ A simple generator of swift files from a given localized POeditor `strings` file
 [![Build Status](https://travis-ci.org/bq/poeditor-parser-swift.svg?branch=master)](https://travis-ci.org/bq/poeditor-parser-swift)
 [![codecov](https://codecov.io/gh/bq/poeditor-parser-swift/branch/master/graph/badge.svg)](https://codecov.io/gh/bq/poeditor-parser-swift)
 
-## Usage
+## Installation
 
-```ogdl
-/bin/poe $APITOKEN $PROJECTID $LANGUAGE
+```
+$ make
 ```
 
-### Options:
-* `--stringfile` [default: Localizable.strings] - The input POEditor strings file directory.
-* `--swiftfile` [default: Literals.swift] - The output Swift file directory.
+## Usage
+```
+Usage:
+
+    $ poe <APITOKEN> <id> <language>
+
+Arguments:
+
+    APITOKEN - The POEditor API token
+    id - The id of the project
+    language - The language code
+
+Options:
+    --swiftfile [default: ${SRCROOT}/${TARGET_NAME}/Literals.swift] - The output Swift file directory.
+    --stringsfile [default: ${SRCROOT}/${TARGET_NAME}/Localizable.strings] - The output Strings file directory.
+```
 
 ## Authors & Collaborators
 

--- a/Sources/POEditorParser/main.swift
+++ b/Sources/POEditorParser/main.swift
@@ -5,7 +5,7 @@ import PerfectCURL
 
 let POEditorAPIURL = "https://api.poeditor.com/v2"
 
-let main = command(
+command(
     Argument<String>("APITOKEN", description: "The POEditor API token"),
     Argument<Int>("id", description: "The id of the project"),
     Argument<String>("language", description: "The language code"),


### PR DESCRIPTION
Before, the compiled binary was distributed with the pod. Now it can be used as an standalone package where you can clone it and use `make` to compile and install the version in your bin directory. This kind of breaks compatibility with cocoapods, that will be deleted because the lack of usage of it.