### PR TITLE
Add AccessModifier to make `Literals` can share outside of the Module

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Arguments:
 Options:
     --swiftfile [default: ${SRCROOT}/${TARGET_NAME}/Literals.swift] - The output Swift file directory.
     --stringsfile [default: ${SRCROOT}/${TARGET_NAME}/Localizable.strings] - The output Strings file directory.
+    --access [default: public] - The access modifier.
 ```
 
 ## Authors & Collaborators

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Options:
     --swiftfile [default: ${SRCROOT}/${TARGET_NAME}/Literals.swift] - The output Swift file directory.
     --stringsfile [default: ${SRCROOT}/${TARGET_NAME}/Localizable.strings] - The output Strings file directory.
     --access [default: public] - The access modifier.
+    --bundle [default: main] - The bundle modifier. It can be only `main` or `module`.
 ```
 
 ## Authors & Collaborators

--- a/Sources/POEditorParser/Lib/LiteralsParser.swift
+++ b/Sources/POEditorParser/Lib/LiteralsParser.swift
@@ -140,10 +140,22 @@ public struct Translation {
          return ""
          }
          */
-        let parameters = variables
+        let uniqueKeyVariables: [Variable] = {
+            guard variables.count > 1 else {
+                return variables
+            }
+
+            return variables
+                .enumerated()
+                .map { (index, variable) in
+                    return .init(rawKey: variable.rawKey + "_\(index)")
+                }
+        }()
+
+        let parameters = uniqueKeyVariables
             .map { $0.type.swiftParameter(key: $0.parameterKey) }
             .joined(separator: ", ")
-        let localizedArguments = variables
+        let localizedArguments = uniqueKeyVariables
             .map { $0.parameterKey }
             .map { $0.snakeCased() }
             .joined(separator: ", ")

--- a/Sources/POEditorParser/Lib/LiteralsParser.swift
+++ b/Sources/POEditorParser/Lib/LiteralsParser.swift
@@ -156,17 +156,19 @@ enum SwiftCodeGeneratorConstants {
         return formatter
     }()
     
-    static let rootObjectHeader = """
-    // Generated using POEditorParser
-    // DO NOT EDIT
-    // Generated: \(SwiftCodeGeneratorConstants.dateFormatter.string(from: Date()))
-    
-    // swiftlint:disable all
+    static func rootObjectHeader(accessModifier: AccessModifier = .public) -> String {
+        """
+        // Generated using POEditorParser
+        // DO NOT EDIT
+        // Generated: \(SwiftCodeGeneratorConstants.dateFormatter.string(from: Date()))
+        
+        // swiftlint:disable all
 
-    import Foundation
-    
-    enum Literals {
-    """
+        import Foundation
+        
+        \(accessModifier.rawValue) enum Literals {
+        """
+    }
     static let rootObjectFooter = "\n}\n// swiftlint:enable all\n"
     
     static let methodOrVariableHeader = "\n"
@@ -181,7 +183,7 @@ class StringCodeGenerator: SwiftCodeGenerator {
     var generatedResult = ""
     
     func generateCode(translations: [Translation]) {
-        generatedResult += SwiftCodeGeneratorConstants.rootObjectHeader
+        generatedResult += SwiftCodeGeneratorConstants.rootObjectHeader()
         
         for t in translations {
             generatedResult += SwiftCodeGeneratorConstants.methodOrVariableHeader
@@ -195,13 +197,18 @@ class StringCodeGenerator: SwiftCodeGenerator {
 public class FileCodeGenerator: SwiftCodeGenerator {
     
     let fileHandle: FileHandle
-    public init(fileHandle: FileHandle) {
+    let accessModifier: AccessModifier
+    public init(
+        fileHandle: FileHandle,
+        access: String
+    ) {
         self.fileHandle = fileHandle
+        self.accessModifier = AccessModifier(accessString: access)
     }
     
     // TODO: Generalize!!! += (same code as in string)
     public func generateCode(translations: [Translation]) {
-        fileHandle += SwiftCodeGeneratorConstants.rootObjectHeader
+        fileHandle += SwiftCodeGeneratorConstants.rootObjectHeader()
         
         for t in translations {
             fileHandle += SwiftCodeGeneratorConstants.methodOrVariableHeader
@@ -361,6 +368,15 @@ enum TranslationValueParser {
         variables.sort(by: { $0.order < $1.order })
         let orderedVariables = variables.map{ $0.variable }
         return (localizedString, orderedVariables)
+    }
+}
+
+
+enum AccessModifier: String {
+    case `public`, `private`, `open`, `internal`
+    
+    init(accessString: String) {
+        self = AccessModifier(rawValue: accessString) ?? .public
     }
 }
 

--- a/Sources/POEditorParser/Lib/LiteralsParser.swift
+++ b/Sources/POEditorParser/Lib/LiteralsParser.swift
@@ -111,24 +111,24 @@ public struct Translation {
         return rawKey.capitalized.replacingOccurrences(of: "_", with: "")
     }
     
-    var swiftCode: String {
+    func swiftCode(accessModifier: AccessModifier = .public) -> String {
         if variables.isEmpty {
-            return generateVariableLessSwiftCode()
+            return generateVariableLessSwiftCode(accessModifier: accessModifier)
         } else {
-            return generateVariableSwiftCode()
+            return generateVariableSwiftCode(accessModifier: accessModifier)
         }
     }
     
-    private func generateVariableLessSwiftCode() -> String {
+    private func generateVariableLessSwiftCode(accessModifier: AccessModifier = .public) -> String {
         /*
          static var Welcome: String {
          return NSLocalizedString()
          }
          */
-        return "\tstatic var \(prettyKey): String {\n\t\treturn \(localizedStringFunction)(\"\(rawKey)\", comment: \"\")\n\t}\n"
+        return "\t\(accessModifier.rawValue) static var \(prettyKey): String {\n\t\treturn \(localizedStringFunction)(\"\(rawKey)\", comment: \"\")\n\t}\n"
     }
     
-    private func generateVariableSwiftCode() -> String {
+    private func generateVariableSwiftCode(accessModifier: AccessModifier = .public) -> String {
         /*
          static func ReadBooksKey(readNumber: Int) -> String {
          return ""
@@ -141,7 +141,7 @@ public struct Translation {
             .map { $0.parameterKey }
             .map { $0.snakeCased() }
             .joined(separator: ", ")
-        return "\tstatic func \(prettyKey)(\(parameters)) -> String {\n\t\treturn String(format: \(localizedStringFunction)(\"\(rawKey)\", comment: \"\"), \(localizedArguments))\n\t}"
+        return "\t\(accessModifier.rawValue) static func \(prettyKey)(\(parameters)) -> String {\n\t\treturn String(format: \(localizedStringFunction)(\"\(rawKey)\", comment: \"\"), \(localizedArguments))\n\t}"
     }
     
 }
@@ -208,11 +208,11 @@ public class FileCodeGenerator: SwiftCodeGenerator {
     
     // TODO: Generalize!!! += (same code as in string)
     public func generateCode(translations: [Translation]) {
-        fileHandle += SwiftCodeGeneratorConstants.rootObjectHeader()
+        fileHandle += SwiftCodeGeneratorConstants.rootObjectHeader(accessModifier: accessModifier)
         
         for t in translations {
             fileHandle += SwiftCodeGeneratorConstants.methodOrVariableHeader
-            fileHandle += t.swiftCode
+            fileHandle += t.swiftCode(accessModifier: accessModifier)
         }
         
         fileHandle += SwiftCodeGeneratorConstants.rootObjectFooter

--- a/Sources/POEditorParser/Lib/LiteralsParser.swift
+++ b/Sources/POEditorParser/Lib/LiteralsParser.swift
@@ -178,22 +178,6 @@ public protocol SwiftCodeGenerator {
     func generateCode(translations: [Translation])
 }
 
-class StringCodeGenerator: SwiftCodeGenerator {
-    
-    var generatedResult = ""
-    
-    func generateCode(translations: [Translation]) {
-        generatedResult += SwiftCodeGeneratorConstants.rootObjectHeader()
-        
-        for t in translations {
-            generatedResult += SwiftCodeGeneratorConstants.methodOrVariableHeader
-            generatedResult += t.swiftCode
-        }
-        
-        generatedResult += SwiftCodeGeneratorConstants.rootObjectFooter
-    }
-}
-
 public class FileCodeGenerator: SwiftCodeGenerator {
     
     let fileHandle: FileHandle

--- a/Sources/POEditorParser/Lib/LiteralsParser.swift
+++ b/Sources/POEditorParser/Lib/LiteralsParser.swift
@@ -29,7 +29,7 @@ struct Variable {
          - alreadyReadPages <- this should not be captialized (or we'll lose the Read and Pages capital letters)
          */
         
-        let words = rawKey.split(separator: " ").map(String.init)
+        let words = rawKey.components(separatedBy: .alphanumerics.inverted)
         if words.count == 1 {
             return words[0].lowercaseFirst
         }

--- a/Sources/POEditorParser/main.swift
+++ b/Sources/POEditorParser/main.swift
@@ -11,8 +11,9 @@ command(
     Argument<String>("language", description: "The language code"),
     Option<String>("swiftfile", default: "${SRCROOT}/${TARGET_NAME}/Literals.swift", description: "The output Swift file directory."),
     Option<String>("stringsfile", default: "${SRCROOT}/${TARGET_NAME}/Localizable.strings", description: "The output Strings file directory."),
-    Option<String>("access", default: "public", description: "The access modifier.")
-) { (token: String, id: Int, language: String, swiftfile: String, stringsfile: String, access: String) in
+    Option<String>("access", default: "public", description: "The access modifier."),
+    Option<String>("bundle", default: "main", description: "The bundle modifier.")
+) { (token: String, id: Int, language: String, swiftfile: String, stringsfile: String, access: String, bundle: String) in
 
     print("Fetching contents of strings at POEditor...".blue)
     
@@ -61,7 +62,7 @@ command(
                 print("Fatal error: Couldn't write to file located at \(swiftfile)".red)
                 return
             }
-            let fileCodeGenerator = FileCodeGenerator(fileHandle: swiftHandle, access: access)
+            let fileCodeGenerator = FileCodeGenerator(fileHandle: swiftHandle, access: access, bundle: bundle)
             fileCodeGenerator.generateCode(translations: translations)
             print("Success! Literals generated at \(swiftfile)".green)
             

--- a/Sources/POEditorParser/main.swift
+++ b/Sources/POEditorParser/main.swift
@@ -10,8 +10,9 @@ command(
     Argument<Int>("id", description: "The id of the project"),
     Argument<String>("language", description: "The language code"),
     Option<String>("swiftfile", default: "${SRCROOT}/${TARGET_NAME}/Literals.swift", description: "The output Swift file directory."),
-    Option<String>("stringsfile", default: "${SRCROOT}/${TARGET_NAME}/Localizable.strings", description: "The output Strings file directory.")
-) { (token: String, id: Int, language: String, swiftfile: String, stringsfile: String) in
+    Option<String>("stringsfile", default: "${SRCROOT}/${TARGET_NAME}/Localizable.strings", description: "The output Strings file directory."),
+    Option<String>("access", default: "public", description: "The access modifier.")
+) { (token: String, id: Int, language: String, swiftfile: String, stringsfile: String, access: String) in
 
     print("Fetching contents of strings at POEditor...".blue)
     
@@ -60,7 +61,7 @@ command(
                 print("Fatal error: Couldn't write to file located at \(swiftfile)".red)
                 return
             }
-            let fileCodeGenerator = FileCodeGenerator(fileHandle: swiftHandle)
+            let fileCodeGenerator = FileCodeGenerator(fileHandle: swiftHandle, access: access)
             fileCodeGenerator.generateCode(translations: translations)
             print("Success! Literals generated at \(swiftfile)".green)
             


### PR DESCRIPTION
Hi, 

This PR has Access Modifier to handle access control for class, functions and variables.
If a project is built in many modules, `Literals` have to make them public to use.

User can use it with `--access` options in the `poe` command. And I wrote down on README.md.
Please review this PR

Regards